### PR TITLE
Fix: re-enable Maven CI workflow + prevent future 60-day disabling

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,23 @@
+name: Keep Workflows Alive
+
+on:
+  schedule:
+    # Run monthly on the 1st at 00:00 UTC.
+    # Resets GitHub's 60-day repository-inactivity timer so that
+    # scheduled workflows (e.g. maven-ci.yml) are never auto-disabled.
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  keepalive:
+    name: Keepalive
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/keepalive-workflow@v3
+        with:
+          # Only create a keepalive commit when the last commit is ≥ 50 days
+          # old (safely below GitHub's 60-day disabling threshold).
+          time-elapsed: 50


### PR DESCRIPTION
## Problem

GitHub disabled the **Maven Build with Java 6 Compatibility** workflow due to 131 days of repository inactivity (last commit: 2026-01-14). This is GitHub's standard policy — scheduled workflows are automatically shut off after 60 days without any repository activity.

Confirmed via `gh workflow list --all`:
```
Maven Build with Java 6 Compatibility   disabled_inactivity   221048560
```

All 5 previous runs were ✅ `ok` — there are no build failures; the workflow was healthy when disabled.

## Root Cause

GitHub's 60-day inactivity policy. jDisco is a maintenance-mode library with infrequent commits, making it structurally prone to hitting this threshold.

## Fix

Add `.github/workflows/keep-alive.yml` using [`peter-evans/keepalive-workflow@v3`](https://github.com/peter-evans/keepalive-workflow):

- Runs on the **1st of every month** (monthly schedule)
- Only creates a keepalive commit when the last commit is **≥ 50 days old** (safely below the 60-day threshold)
- **No-op** when the repo has had recent activity — no unnecessary empty commits
- Self-sustaining: the keep-alive workflow itself will never be disabled because it runs every 30 days

Merging this PR to `main` automatically re-enables the disabled `maven-ci.yml` scheduled workflow (the push to main resets the inactivity clock).

## No other changes

- `pom.xml` — unchanged (JDK 11 + Java 6 source/target retained)
- `maven-ci.yml` — unchanged (CI was passing; nothing to fix)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)